### PR TITLE
Atualização das configurações para a criação da instância

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -6,7 +6,6 @@ on:
       - main
   pull_request: {}
   workflow_dispatch: {}
-  pull_request_target: {}
 
 permissions:
   contents: read

--- a/database.tf
+++ b/database.tf
@@ -1,24 +1,22 @@
 resource "aws_db_instance" "postgres-instance" {
-  allocated_storage     = 20
-  engine                = "postgres"
-  engine_version        = "14.9"
-  identifier            = "lanchonete-database" # Nome do banco de dados
-  instance_class        = "db.t3.medium"
-  username              = var.dbUsername #TODO - mudar para o terraform.tfvars
-  password              = var.dbSecret   #TODO - mudar para o terraform.tfvars
-
-  parameter_group_name = "default.postgres14" # Grupo de parâmetros padrão
-  publicly_accessible  = false                # Restringir acesso público
-
+  allocated_storage      = 20
+  engine                 = "postgres"
+  engine_version         = "14.9"
+  identifier             = "lanchonete-database" # Nome do banco de dados
+  instance_class         = "db.t3.medium"
+  username               = var.dbUsername       #TODO - mudar para o terraform.tfvars
+  password               = var.dbSecret         #TODO - mudar para o terraform.tfvars
+  parameter_group_name   = "default.postgres14" # Grupo de parâmetros padrão
+  publicly_accessible    = false                # Restringir acesso público
   vpc_security_group_ids = [aws_security_group.db_sg.id]
 
   #TODO - falta configurar
   #db_subnet_group_name   = aws_db_subnet_group.default.id
 
   # Configuração de backup
-  maintenance_window       = "Tue:00:00-Tue:03:00"
-  backup_window            = "03:00-06:00"
-  backup_retention_period  = 30
+  maintenance_window      = "Tue:00:00-Tue:03:00"
+  backup_window           = "03:00-06:00"
+  backup_retention_period = 30
 
   tags = {
     Name = "PostgresDatabase"

--- a/database.tf
+++ b/database.tf
@@ -1,42 +1,27 @@
-# Configuração do banco de dados RDS PostgreSQL
-resource "aws_db_instance" "postgres" {
-  identifier = "lanchonete-database" # Nome do banco de dados
-
-  # Tamanho de GB
-  allocated_storage     = 10
-  max_allocated_storage = 30 #máximo permitido
-
-  # Tipo e versão do banco
-  engine         = "postgres"
-  engine_version = "14.5"
-
-  # Classe da instância atualizada de acordo com o instance type usando para o k8s - t3a.medium
-  instance_class = "db.t3.medium"
-
-  # Mesmo nome e senha que estava no projeto
-  username = var.dbUsername #TODO - mudar para o terraform.tfvars
-  password = var.dbSecret   #TODO - mudar para o terraform.tfvars
+resource "aws_db_instance" "postgres-instance" {
+  allocated_storage     = 20
+  engine                = "postgres"
+  engine_version        = "14.9"
+  identifier            = "lanchonete-database" # Nome do banco de dados
+  instance_class        = "db.t3.medium"
+  username              = var.dbUsername #TODO - mudar para o terraform.tfvars
+  password              = var.dbSecret   #TODO - mudar para o terraform.tfvars
 
   parameter_group_name = "default.postgres14" # Grupo de parâmetros padrão
   publicly_accessible  = false                # Restringir acesso público
 
-  # O valor de id, será criado quando o serviço para criar essa estrutura for executada
   vpc_security_group_ids = [aws_security_group.db_sg.id]
 
   #TODO - falta configurar
   #db_subnet_group_name   = aws_db_subnet_group.default.id
 
   # Configuração de backup
-  backup_retention_period = 7             # Retenção de backups (em dias)
-  backup_window           = "02:00-03:00" # Janela para backups
-
-  # Janela de manutenção
-  maintenance_window = "Mon:03:00-Mon:04:00"
+  maintenance_window       = "Tue:00:00-Tue:03:00"
+  backup_window            = "03:00-06:00"
+  backup_retention_period  = 30
 
   tags = {
     Name = "PostgresDatabase"
     Env  = "Production"
   }
-
-  # irá interagir com o lambda, se sim configurar o IAM roles
 }


### PR DESCRIPTION
# Objetivo do PR

## Cenário
Após merge com a main no PR #2, a action parou na criação da instância, devido a versão do banco.



## Implementação
Atualizada a versão do postgre para uma versão suportada.

### Pontos importantes
- A versão do banco escolhida não é mais suportada, alterado para a versão 14.9. 
  - [Relação das versões suportadas do postgres pelo RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.PostgreSQL.MajorVersion.html)


### Pendências
- Passar as chaves que existem do banco atualmente no código para a AWS, com terraform.tfvars
- Configurar as subnets